### PR TITLE
Add ngrok.set_auth_token(token)

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,5 +1,8 @@
 use lazy_static::lazy_static;
-use log::info;
+use log::{
+    debug,
+    info,
+};
 use pyo3::{
     pyfunction,
     types::{
@@ -445,7 +448,7 @@ pub fn disconnect(py: Python, url: Option<Py<PyString>>) -> PyResult<Py<PyAny>> 
 
 #[pyfunction]
 pub fn async_disconnect(py: Python, url: Option<String>) -> PyResult<&PyAny> {
-    info!("async Disconnecting");
+    debug!("Disconnecting. url: {url:?}");
     pyo3_asyncio::tokio::future_into_py(py, async move {
         tunnel::close_url(url.clone()).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,10 @@ use crate::{
         kill,
     },
     logging::log_level,
+    session::set_auth_token,
     tunnel::{
         async_tunnels,
-        tunnels,
+        get_tunnels,
     },
     wrapper::{
         default,
@@ -72,7 +73,8 @@ fn ngrok(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(listen, m)?)?;
     m.add_function(wrap_pyfunction!(log_level, m)?)?;
     m.add_function(wrap_pyfunction!(pipe_name, m)?)?;
-    m.add_function(wrap_pyfunction!(tunnels, m)?)?;
+    m.add_function(wrap_pyfunction!(set_auth_token, m)?)?;
+    m.add_function(wrap_pyfunction!(get_tunnels, m)?)?;
     m.add_function(wrap_pyfunction!(werkzeug_develop, m)?)?;
 
     m.add_class::<NgrokSessionBuilder>()?;

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -537,7 +537,7 @@ pub(crate) async fn list_tunnels(session_id: Option<String>) -> PyResult<Vec<Ngr
 
 /// Retrieve a list of non-closed tunnels, in no particular order.
 #[pyfunction]
-pub fn tunnels(py: Python) -> PyResult<Py<PyAny>> {
+pub fn get_tunnels(py: Python) -> PyResult<Py<PyAny>> {
     // move to async, handling if there is an async loop running or not
     wrapper::loop_wrap(py, None, "    return await ngrok.async_tunnels()")
 }

--- a/test/test.py
+++ b/test/test.py
@@ -104,7 +104,7 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(tunnel.url().startswith("https://"))
         self.assertEqual("http forwards to", tunnel.forwards_to())
         self.assertEqual("http metadata", tunnel.metadata())
-        tunnel_list = await session.tunnels()
+        tunnel_list = await session.get_tunnels()
         self.assertEqual(1, len(tunnel_list))
         self.assertEqual(tunnel.id(), tunnel_list[0].id())
         self.assertEqual(tunnel.url(), tunnel_list[0].url())
@@ -375,9 +375,9 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
         tunnel3.forward_tcp(http_server.listen_to)
         tunnel4.forward_tcp(http_server.listen_to)
 
-        self.assertEqual(2, len(await session1.tunnels()))
-        self.assertEqual(2, len(await session2.tunnels()))
-        self.assertTrue(len(await ngrok.tunnels()) > 4)
+        self.assertEqual(2, len(await session1.get_tunnels()))
+        self.assertEqual(2, len(await session2.get_tunnels()))
+        self.assertTrue(len(await ngrok.get_tunnels()) > 4)
 
         await self.validate_http_request(tunnel1.url())
         await self.validate_http_request(tunnel2.url())

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -1,4 +1,5 @@
 import ngrok
+import os
 import requests
 import unittest
 import test
@@ -40,9 +41,9 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
 
     def test_https_tunnel(self):
         http_server = test.make_http()
+        ngrok.set_auth_token(os.environ["NGROK_AUTHTOKEN"])
         tunnel = ngrok.connect(
             http_server.listen_to,
-            authtoken_from_env=True,
             forwards_to="http forwards to",
             metadata="http metadata",
         )
@@ -52,7 +53,7 @@ class TestNgrok(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(tunnel.url().startswith("https://"))
         self.assertEqual("http forwards to", tunnel.forwards_to())
         self.assertEqual("http metadata", tunnel.metadata())
-        self.assertTrue(len(ngrok.tunnels()) >= 1)
+        self.assertTrue(len(ngrok.get_tunnels()) >= 1)
 
         self.validate_shutdown(http_server, tunnel, tunnel.url())
 


### PR DESCRIPTION
Adding `ngrok.set_auth_token(token)`, a feature `ngrok-nodejs` has, as well as the main community nodejs and python libraries. Also renames `tunnels` to `get_tunnels` to match other libraries.