### PR TITLE
Switch to vmactions/freebsd-vm@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,15 +153,17 @@ jobs:
   build-freebsd:
     if: github.ref == 'refs/heads/main'
     needs: decide
-    runs-on: macos-12
+    runs-on: ubuntu-22.04
     name: Build FreeBSD
-    timeout-minutes: 30
+    timeout-minutes: 20
     continue-on-error: true
     steps:
+      - name: Run lscpu
+        run: lscpu
       - uses: actions/checkout@v3
       - name: Build
         id: build
-        uses: vmactions/freebsd-vm@v0
+        uses: vmactions/freebsd-vm@v1
         env:
           DEBUG: napi:*
           RUSTUP_HOME: /usr/local/rustup


### PR DESCRIPTION
Github action was updated upstream: https://github.com/vmactions/freebsd-vm/issues/74#issuecomment-1798014978

Works generally well for [ngrok-nodejs](https://github.com/ngrok/ngrok-nodejs/pull/102), has issues here when on Intel runners, but is still more stable than the previous incarnation, and will likely get more solid when they support mac hardware again.

Started recording processor type after reading: [why-github-actions-is-so-slow](https://buildjet.com/for-github-actions/blog/why-github-actions-is-so-slow)