### PR TITLE
add app-protocol to http builder/forward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ run: develop
 run-aio: develop examples-install
 	. $(BIN)/activate && python ./examples/aiohttp-ngrok.py
 
+run-http2: develop examples-install
+	. $(BIN)/activate && python ./examples/hypercorn-http2-ngrok.py
+
 run-forward-full: develop
 	. $(BIN)/activate && python ./examples/ngrok-forward-full.py
 

--- a/README.md
+++ b/README.md
@@ -406,3 +406,33 @@ export NGROK_AUTHTOKEN="YOUR_AUTHTOKEN_HERE"; make test="-k TEST_CLASS.NAME_OF_T
 ```
 
 [See the MakeFile for more examples](./Makefile)
+
+### HTTP2 
+
+The examples include a minimal `hypercorn` HTTP/2 example if you run `make http2`. You can curl the endpoint logged with `INFO:ngrok.listener:Created` and verify the HTTP/2 response from `hypercorn`.
+
+```bash
+curl --http2 -v https://<YOUR_LISTENER_URL>
+*   Trying <YOUR_IP>:443...
+* Connected to a6278d6c07ce.ngrok.app (<YOUR_IP>) port 443 (#0)
+* ALPN, offering h2
+* ALPN, offering http/1.1
+...
+> GET / HTTP/2
+> Host: a6278d6c07ce.ngrok.app
+> user-agent: curl/7.81.0
+> accept: */*
+>
+...
+< HTTP/2 200
+< content-type: text/plain
+< date: Fri, 01 Mar 2024 18:50:23 GMT
+< ngrok-agent-ips: <YOUR_AGENT_IP>
+< ngrok-trace-id: ed038ace04876818149cf0769bd43e38
+< server: hypercorn-h2
+<
+* TLSv1.2 (IN), TLS header, Supplemental data (23):
+* TLSv1.2 (IN), TLS header, Supplemental data (23):
+* Connection #0 to host <YOUR_LISTENER_URL> left intact
+hello
+```

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This example shows [all the possible configuration items of ngrok.forward](https
 ```python
 listener = ngrok.forward(
     # session configuration
+    app_protocol="http2",
     addr="localhost:8080",
     authtoken="<authtoken>",
     authtoken_from_env=True,

--- a/examples/hypercorn-http2-ngrok.py
+++ b/examples/hypercorn-http2-ngrok.py
@@ -1,0 +1,30 @@
+import asyncio
+import ngrok
+import logging
+from hypercorn.config import Config
+from hypercorn.asyncio import serve
+
+config = Config()
+
+async def app(scope, receive, send):
+    await send({
+        'type': 'http.response.start',
+        'status': 200,
+        'headers': [
+            (b'content-type', b'text/plain'),
+        ],
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': b'hello',
+    })
+
+
+logging.basicConfig(level=logging.INFO)
+tun = ngrok.forward(addr="localhost:8080", authtoken_from_env=True, app_protocol="http2")
+config.bind = ["localhost:8080"]
+asyncio.run(serve(app, config))
+
+
+
+

--- a/examples/hypercorn-http2-ngrok.py
+++ b/examples/hypercorn-http2-ngrok.py
@@ -21,10 +21,6 @@ async def app(scope, receive, send):
 
 
 logging.basicConfig(level=logging.INFO)
-tun = ngrok.forward(addr="localhost:8080", authtoken_from_env=True, app_protocol="http2")
+ngrok.forward(addr="localhost:8080", authtoken_from_env=True, app_protocol="http2")
 config.bind = ["localhost:8080"]
 asyncio.run(serve(app, config))
-
-
-
-

--- a/examples/ngrok-http-full.py
+++ b/examples/ngrok-http-full.py
@@ -53,6 +53,7 @@ async def create_listener(httpd: Union[TCPServer, UnixStreamServer]) -> None:
         await session.http_endpoint()
         # .allow_cidr("0.0.0.0/0")
         # .allow_user_agent("^mozilla.*")
+        # .app_protocol("http2")
         # .basic_auth("ngrok", "online1line")
         # .circuit_breaker(0.5)
         # .compression()

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -6,3 +6,4 @@ streamlit==1.22.0
 tornado==6.3.1
 uvicorn==0.21.0
 Werkzeug==2.2.2
+Hypercorn==0.16.0

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -291,6 +291,7 @@ async fn http_endpoint(session: &Session, addr: String, options: Py<PyDict>) -> 
         plumb_vec!(B, bld, cfg, scheme, schemes);
         plumb!(B, bld, cfg, domain, hostname); // synonym for domain
         plumb!(B, bld, cfg, domain);
+        plumb!(B, bld, cfg, app_protocol);
         plumb_vec!(B, bld, cfg, mutual_tlsca, mutual_tls_cas, vecu8);
         plumb_bool!(B, bld, cfg, compression);
         plumb_bool!(

--- a/src/http.rs
+++ b/src/http.rs
@@ -17,6 +17,14 @@ use crate::listener_builder::HttpListenerBuilder;
 #[pymethods]
 #[allow(dead_code)]
 impl HttpListenerBuilder {
+    /// The L7 protocol to use for this edge: "http1" or "http2".
+    pub fn app_protocol(self_: PyRefMut<Self>, app_protocol: String) -> PyRefMut<Self> {
+        self_.set(|b| {
+            b.app_protocol(app_protocol);
+        });
+        self_
+    }
+
     /// The scheme that this edge should use.
     /// "HTTPS" or "HTTP", defaults to "HTTPS".
     pub fn scheme(self_: PyRefMut<Self>, scheme: String) -> PyRefMut<Self> {


### PR DESCRIPTION
Part of #80 

Completes adding an example for http2 utilizing `app_protocol` in our forwarding setup.

In a follow up, we'll add `app_protocol` plumbing to the labeled listener.

### Notes

Testing and example setup were not quite trivial in the synchronous set of python tooling. We were able to validate our examples and `app_protocol` integration through `curl --http2 -v <LISTENER_URL>` calls and see things working correctly.  We add a not into the Readme to help other quickly validate. 

Future work could explore adding a test to our `test_connect.py` once we identify an `http2` python client we'd like to utilize for that. `httpx` seems to have documented `http2` support with its `httpx[http2]` module installed.