### PR TITLE
add app_protocol to labeled listeners

### DIFF
--- a/examples/ngrok-labeled.py
+++ b/examples/ngrok-labeled.py
@@ -19,6 +19,8 @@ async def create_listener() -> ngrok.Listener:
         await session.labeled_listener()
         .label("edge", "edghts_<edge_id>")
         .metadata("example listener metadata from python")
+        # Set the application protocol to "http1" or "http2"
+        # .app_protocol("http2")
         .listen()
     )
 
@@ -32,6 +34,8 @@ def create_listener_connect(addr):
         authtoken_from_env=True,
         labels="edge:edghts_<edge_id>",
         proto="labeled",
+        # Set the application protocol to "http1" or "http2"
+        # app_protocol="http2",
     )
 
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -415,6 +415,7 @@ async fn labeled_listener(
         let cfg = options.as_ref(py);
         type B = LabeledListenerBuilder;
         plumb!(B, bld, cfg, metadata);
+        plumb!(B, bld, cfg, app_protocol);
         plumb_vec!(B, bld, cfg, label, labels, ":");
         Ok::<_, PyErr>(bld.replace(session.labeled_listener()))
     })?;

--- a/src/listener_builder.rs
+++ b/src/listener_builder.rs
@@ -231,6 +231,12 @@ macro_rules! make_listener_builder {
                 self_.set(|b| {b.label(label, value);});
                 self_
             }
+
+            /// Set the L7 application protocol used for this listener, i.e. "http1" or "http2" (default "http1")
+            pub fn app_protocol(self_: PyRefMut<Self>, app_protocol: String) -> PyRefMut<Self> {
+                self_.set(|b| {b.app_protocol(app_protocol);});
+                self_
+            }
         }
     };
 }


### PR DESCRIPTION
Closes #80

Closes out the ticket for `app_protocol` support in listeners with `app_protocol`  in labeled in listener builders and forwarding.