### PR TITLE
adding the root_cas option to SessionBuilder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,11 @@ jobs:
             ls -lah
             whoami
             env
+            echo "apk add:"
+            apk add python3-dev
+            echo "apk update:"
             apk update
+            echo "create venv:"
             python3 -m venv .env
             . .env/bin/activate && pip install -r requirements.txt
             . .env/bin/activate && pip install patchelf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 # pin mio until all dependencies are also on windows-sys 0.48
 # https://github.com/microsoft/windows-rs/issues/2410#issuecomment-1490802715
 mio = { version = "=0.8.6" }
-ngrok = { version = "=0.14.0-pre.12" }
+ngrok = { version = "=0.14.0-pre.13" }
 pyo3 = { version = "0.18.1", features = ["abi3", "abi3-py37", "extension-module", "multiple-pymethods"]}
 pyo3-asyncio = { version = "0.18.0", features = ["attributes", "tokio-runtime"] }
 pyo3-log = { version = "0.8.1" }

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ listener = ngrok.forward(
     authtoken_from_env=True,
     app_protocol="http2",
     session_metadata="Online in One Line",
+    # advanced session connection configuration
+    server_addr="example.com:443",
+    root_cas="trusted",
+    session_ca_cert=load_file("ca.pem"),
     # listener configuration
     metadata="example listener metadata from python",
     domain="<domain>",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.4
+aiohttp==3.9.5
 black==23.3.0
 furo==2022.12.7
 maturin==0.14.16

--- a/src/session.rs
+++ b/src/session.rs
@@ -272,7 +272,24 @@ impl SessionBuilder {
     /// .. _server_addr parameter in the ngrok docs: https://ngrok.com/docs/ngrok-agent/config#server_addr
     pub fn server_addr(self_: PyRefMut<Self>, addr: String) -> PyRefMut<Self> {
         self_.set(|b| {
-            b.server_addr(addr).expect("fixme");
+            b.server_addr(&addr)
+                .unwrap_or_else(|_| panic!("failed to parse addr: {addr}"));
+        });
+        self_
+    }
+
+    /// Sets the file path to a default certificate in PEM format to validate ngrok Session TLS connections.
+    /// Setting to "trusted" is the default, using the ngrok CA certificate.
+    /// Setting to "host" will verify using the certificates on the host operating system.
+    /// A client config set via tls_config after calling root_cas will override this value.
+    ///
+    /// Corresponds to the `root_cas parameter in the ngrok docs`_
+    ///
+    /// .. _root_cas parameter in the ngrok docs: https://ngrok.com/docs/ngrok-agent/config#root_cas
+    pub fn root_cas(self_: PyRefMut<Self>, root_cas: String) -> PyRefMut<Self> {
+        self_.set(|b| {
+            b.root_cas(&root_cas)
+                .unwrap_or_else(|_| panic!("failed to invoke root_cas: {root_cas}"));
         });
         self_
     }

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -242,6 +242,7 @@ class TestNgrokConnect(unittest.IsolatedAsyncioTestCase):
             error = err
         self.assertIsInstance(error, ValueError)
         self.assertTrue("parse policy" in f"{error}")
+        shutdown(None, http_server)
 
     def test_root_cas(self):
         http_server = test.make_http()

--- a/test/test_connect.py
+++ b/test/test_connect.py
@@ -243,6 +243,37 @@ class TestNgrokConnect(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(error, ValueError)
         self.assertTrue("parse policy" in f"{error}")
 
+    def test_root_cas(self):
+        http_server = test.make_http()
+        error = None
+        # tls error connecting to marketing site
+        try:
+            listener = ngrok.connect(
+                http_server.listen_to,
+                authtoken_from_env=True,
+                force_new_session=True,
+                root_cas="trusted",
+                server_addr="ngrok.com:443",
+            )
+        except ValueError as err:
+            error = err
+        self.assertIsInstance(error, ValueError)
+        self.assertTrue("tls handshake" in f"{error}", error)
+
+        # non-tls error connecting to marketing site with "host" root_cas
+        try:
+            listener = ngrok.connect(
+                http_server.listen_to,
+                authtoken_from_env=True,
+                force_new_session=True,
+                root_cas="host",
+                server_addr="ngrok.com:443",
+            )
+        except ValueError as err:
+            error = err
+        self.assertIsInstance(error, ValueError)
+        self.assertFalse("tls handshake" in f"{error}", error)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds `root_cas` to SessionBuilder and `forward()`. Also adds `ca_cert` and `server_addr` to `forward()`.

Related to: https://github.com/ngrok/ngrok-rust/issues/141