### PR TITLE
1.4.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,5 +19,6 @@ Release
     - Or with graphite: `gt branch track` and `gt stack submit`
 1. Create a pull request off this branch
     - Make sure the name of the pull request is also just the `<version>` so the workflow will know to do a release
+    - Do not prepend the `<version>` with `v`. For instance, if releasing `1.1.0`, the PR should be named `1.1.0`, NOT `v1.1.0`
 1. Merge the pull request
 1. Verify release appears on [PyPI](https://pypi.org/project/ngrok/#history)

--- a/examples/ngrok-forward-full.py
+++ b/examples/ngrok-forward-full.py
@@ -7,7 +7,7 @@ import asyncio
 
 class HelloHandler(BaseHTTPRequestHandler):
     def do_GET(self):
-        body = bytes("Hello", "utf-8")
+        body = bytes("Hello!", "utf-8")
         self.protocol_version = "HTTP/1.1"
         self.send_response(200)
         self.send_header("Content-Length", len(body))


### PR DESCRIPTION
I missed the note about needing to name the branch properly in order to trigger a release.