### PR TITLE
Release 1.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - 'main'
+      - '**'
     tags-ignore:
       - '**'
     paths-ignore:
@@ -15,7 +15,11 @@ on:
       - '**/*.gitignore'
       - .editorconfig
       - docs/**
-  pull_request: null
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
 jobs:
   udeps:
     name: Udeps


### PR DESCRIPTION
Loosen up the build situation, matching what we do for the javascript SDK.

This isn't technically correct, but I'm a bit fed up with this at this point and it works well enough over in JS land, so here's to hoping